### PR TITLE
change default number of threads used by wsclean from 4 to 1

### DIFF
--- a/ovrolwasolar/deconvolve.py
+++ b/ovrolwasolar/deconvolve.py
@@ -68,7 +68,7 @@ def run_wsclean(msfile, imagename, size:int =4096, scale='2arcmin', fast_vis=Fal
     logging.debug("Running WSCLEAN")
     
     default_kwargs={
-        'j':'4',                    # number of threads
+        'j':'1',                    # number of threads
         'mem':'2',                 # fraction of memory usage
         'weight':'uniform',         # weighting scheme
         'no_dirty':'',              # don't save dirty image
@@ -155,7 +155,7 @@ def run_wsclean(msfile, imagename, size:int =4096, scale='2arcmin', fast_vis=Fal
     if predict:
         logging.debug("Predicting model visibilities from " + imagename + " in " + msfile)
         time1 = timeit.default_timer()
-        os.system("wsclean -j 4 -mem 2 -no-reorder -predict -pol "+default_kwargs['pol']+" "+ "-name " + imagename + " " + msfile)
+        os.system("wsclean -j 1 -mem 2 -no-reorder -predict -pol "+default_kwargs['pol']+" "+ "-name " + imagename + " " + msfile)
         time2 = timeit.default_timer()
         logging.debug('Time taken for predicting the model column is {0:.1f} s'.format(time2-time1))
 
@@ -195,7 +195,7 @@ def predict_model(msfile, outms, image="_no_sun",pol='I'):
     """
     os.system("cp -r " + msfile + " " + outms)
     clearcal(outms, addmodel=True)
-    os.system("wsclean -j 4 -mem 2 -no-reorder -predict -pol "+pol+" -name " + image + " " + outms)
+    os.system("wsclean -j 1 -mem 2 -no-reorder -predict -pol "+pol+" -name " + image + " " + outms)
 
 
 

--- a/ovrolwasolar/source_subtraction.py
+++ b/ovrolwasolar/source_subtraction.py
@@ -35,7 +35,7 @@ def make_fullsky_image(msfile, imagename="allsky", imsize=4096, cell='2arcmin',
     :param minuv: minimum uv to consider for imaging (in # of wavelengths)
     :return: produces wsclean images (fits), PSF, etc.
     """
-    os.system("wsclean -j 4 -mem 2 -no_reorder -no-update-model-required -weight uniform" +
+    os.system("wsclean -j 1 -mem 2 -no_reorder --horizon_mask 2deg -no-update-model-required -weight uniform" +
               " -name " + imagename + " -size " + str(imsize) + " " + str(imsize) + " -scale " + cell +
               " -minuv-l " + str(minuv) + " -niter 1000 -pol "+pol+' '+ msfile)
 

--- a/ovrolwasolar/source_subtraction.py
+++ b/ovrolwasolar/source_subtraction.py
@@ -22,24 +22,6 @@ cl = componentlist()
 msmd = msmetadata()
 
 
-
-def make_fullsky_image(msfile, imagename="allsky", imsize=4096, cell='2arcmin',
-                       minuv=10,pol='I'):  ### minuv: minimum uv in lambda
-    """
-    Make all sky image with wsclean
-    
-    :param msfile: path to CASA measurement set
-    :param imagename: output image name
-    :param imsize: size of the image in pixels
-    :param cell: pixel scale
-    :param minuv: minimum uv to consider for imaging (in # of wavelengths)
-    :return: produces wsclean images (fits), PSF, etc.
-    """
-    os.system("wsclean -j 1 -mem 2 -no_reorder --horizon_mask 2deg -no-update-model-required -weight uniform" +
-              " -name " + imagename + " -size " + str(imsize) + " " + str(imsize) + " -scale " + cell +
-              " -minuv-l " + str(minuv) + " -niter 1000 -pol "+pol+' '+ msfile)
-
-
 def get_solar_loc_pix(msfile, image="allsky"):
     """
     Get the x, y pixel location of the Sun from an all-sky image


### PR DESCRIPTION
Also, to avoid the artifacts at high frequencies (I have seen realtime images with a reduced quality), add "--horizon_mask 2deg"  when producing all-sky images for source subtraction.