### PR TITLE
Various bug fixes and updates for refraction correction, compression, and visualization

### DIFF
--- a/ovrolwasolar/refraction_correction.py
+++ b/ovrolwasolar/refraction_correction.py
@@ -127,8 +127,8 @@ def refraction_fit_param(fname, thresh_freq=45e6, overbright=2.0e6, min_freqfrac
     # peak_values_for_fit_v1 = peak_values_for_fit[idx_not_too_bright]
 
     # linear fit
-    #if freq_for_fit_v1.size > max(int(len(idx_for_gt_freqthresh[0]) * min_freqfrac), 5):
-    if freq_for_fit_v1.size > 5:
+    if freq_for_fit_v1.size > max(int(len(idx_for_gt_freqthresh[0]) * min_freqfrac), 5):
+    #if freq_for_fit_v1.size > 5:
         px = np.polyfit(1 / freq_for_fit_v1 ** 2, com_x_for_fit_v1, 1)
         py = np.polyfit(1 / freq_for_fit_v1 ** 2, com_y_for_fit_v1, 1)
     else:

--- a/ovrolwasolar/utils.py
+++ b/ovrolwasolar/utils.py
@@ -433,3 +433,91 @@ def correct_primary_beam(msfile, imagename, pol='I', fast_vis=False):
                 hdu.close()
     return
 
+
+def compress_fits_to_h5(fits_file, hdf5_file=None):
+    """
+    Compress an OVRO-LWA fits file to a h5 files
+    
+    :param fits_file: the fits file to be compressed
+    :param hdf5_file: the h5 file to be saved. If not given, default to '{filename}.hdf' in current directory
+    """
+    import h5py
+    from scipy.ndimage import zoom
+
+    if hdf5_file is None:
+        hdf5_file = './' + os.path.basename(fits_file).replace('.fits', '.hdf')
+
+    hdul = fits.open(fits_file)
+    data = hdul[0].data
+    header = hdul[0].header
+
+    # ch_vals
+    # [('cfreqs', '>f4'), ('cdelts', '>f4'), ('bmaj', '>f4'), ('bmin', '>f4'), ('bpa', '>f4')]
+    ch_vals = []
+    for ch_val in hdul[1].data.dtype.names:
+        ch_vals.append(hdul[1].data[ch_val])
+    ch_vals = np.array(ch_vals)
+
+    downsize_ratio = (hdul[1].data['bmin']*3600)/ 3 / hdul[0].header['CDELT2']
+    recover_data  = np.zeros_like(data)
+    with h5py.File(hdf5_file, 'w') as f:
+        # Create a dataset for the FITS data
+        for pol in range(0, data.shape[0]):
+            for ch_idx in range(0, len(downsize_ratio)):
+                downsized_data = zoom(data[0,ch_idx,:,:], 1/downsize_ratio[ch_idx], order=5)
+                dset = f.create_dataset('FITS_pol'+str(pol)+'ch'+str(ch_idx).rjust(4,'0') , data=downsized_data,compression="gzip", compression_opts=9)
+                recover_data[0,ch_idx,:,:] = zoom(downsized_data, data.shape[-1]/downsized_data.shape[-1], order=5)
+            
+            # Add FITS header info as attributes
+        dset = f.create_dataset('ch_vals', data=ch_vals)
+        dset.attrs['arr_name'] = hdul[1].data.dtype.names
+        dset.attrs['original_shape'] = data.shape
+        for key, value in header.items():
+            dset.attrs[key] = value
+
+
+def recover_fits_from_h5(hdf5_file, fits_out=None):
+    """
+    Recover a fits file from a compressed hdf5 file
+    
+    :param hdf5_file: the hdf5 file to be read
+    :param fits_out: the fits file to be recovered. If not given, default to '{filename}.fits' in current directory
+    """
+    import h5py
+    from scipy.ndimage import zoom
+
+    if fits_out is None:
+        fits_out = './' + os.path.basename(hdf5_file).replace('.hdf', '.fits')
+
+    with h5py.File(hdf5_file, 'r') as f:
+        # Read in the ch_vals
+        ch_vals = f['ch_vals'][:]
+        ch_vals_names = f['ch_vals'].attrs['arr_name']
+        ch_vals = {ch_vals_names[i]:ch_vals[i] for i in range(len(ch_vals_names))}
+        attaching_columns = []
+        for key in ch_vals.keys():
+            attaching_columns.append(fits.Column(name=key, format='E', array=ch_vals[key]))
+
+        datashape = f['ch_vals'].attrs['original_shape']
+
+        # Read in the compressed data
+        recover_data = np.zeros(datashape)
+        for pol in range(0, datashape[0]):
+            for ch_idx in range(0, len(ch_vals['cfreqs'])):
+                tmp_small=f['FITS_pol'+str(pol)+'ch'+str(ch_idx).rjust(4,'0')][:]
+                recover_data[pol,ch_idx,:,:] = zoom(tmp_small, datashape[-1]/tmp_small.shape[-1], order=5)
+
+        # Read in the header
+        header = {}
+        for key in f['ch_vals'].attrs.keys():
+            header[key] = f['ch_vals'].attrs[key]
+        
+        header.pop('arr_name', None)
+        header.pop('original_shape', None)
+
+        # convert header to fits header obj
+        header = fits.Header(header)
+
+        # Write out the recovered FITS file 
+        hdu_list = fits.HDUList([fits.PrimaryHDU(recover_data, header), fits.BinTableHDU.from_columns(attaching_columns)])
+        hdu_list.writeto(fits_out, overwrite=True)

--- a/ovrolwasolar/visualization.py
+++ b/ovrolwasolar/visualization.py
@@ -72,7 +72,7 @@ def inspection_bl_flag(ms_file):
 
 def slow_pipeline_default_plot(fname, 
             freqs_plt = [34.1, 38.7, 43.2, 47.8, 52.4, 57.0, 61.6, 66.2, 70.8, 75.4, 80.0, 84.5],
-            fov = 7998,add_logo=True, apply_refraction_corr=False):
+            fov = 7998, add_logo=True, apply_refraction_param=False):
     """
     Function to plot the default pipeline output
 
@@ -80,91 +80,97 @@ def slow_pipeline_default_plot(fname,
     :param freqs_plt: list : list of frequencies to plot
     :param fov: float : field of view (default -3999 to 3999 arcsec)
     :param add_logo: bool : add logo to the plot
-    :param apply_refraction_corr: bool : apply refraction correction to the plot
+    :param apply_refraction_param: bool : apply refraction correction to the plot. 
+                Will be ignored if REFCOR in the FITS header is True
     """
     # Load the data
 
     from suncasa.io import ndfits
     meta, rdata = ndfits.read(fname)
+    if 'rfrcor' in meta['header']:
+        rfrcor = meta['header']
+    else:
+        rfrcor = False
 
     fig = plt.figure(figsize=(8, 6.5))
     gs = gridspec.GridSpec(3, 4, left=0.07, right=0.98, top=0.94, bottom=0.10, wspace=0.02, hspace=0.02)
 
     if True:
-                freqs_mhz = meta['ref_cfreqs']/1e6
-                for i in range(12):
-                    ax = fig.add_subplot(gs[i])
-                    freq_plt = freqs_plt[i]
-                    ax.set_facecolor('black')
-                    plt.setp(ax,xlabel='Solar X [arcsec]', ylabel='Solar Y [arcsec]')
-                    ax.text(0.02, 0.98, '{0:.0f} MHz'.format(freq_plt), color='w', ha='left', va='top', 
-                            fontsize=11, transform=ax.transAxes)                
-                    plt.setp(ax.yaxis.get_majorticklabels(),
-                              rotation=90, ha="center", va="center", rotation_mode="anchor")
+        freqs_mhz = meta['ref_cfreqs']/1e6
+        for i in range(12):
+            ax = fig.add_subplot(gs[i])
+            freq_plt = freqs_plt[i]
+            ax.set_facecolor('black')
+            plt.setp(ax,xlabel='Solar X [arcsec]', ylabel='Solar Y [arcsec]')
+            ax.text(0.02, 0.98, '{0:.0f} MHz'.format(freq_plt), color='w', ha='left', va='top', 
+                    fontsize=11, transform=ax.transAxes)                
+            plt.setp(ax.yaxis.get_majorticklabels(),
+                      rotation=90, ha="center", va="center", rotation_mode="anchor")
 
-                    if np.min(np.abs(freqs_mhz - freq_plt)) < 2.:
-                        bd = np.argmin(np.abs(freqs_mhz - freq_plt)) 
-                        bmaj,bmin,bpa = meta['bmaj'][bd],meta['bmin'][bd],meta['bpa'][bd]
-                        beam0 = Ellipse((-fov/2*0.75, -fov/2*0.75), bmaj*3600,
-                                bmin*3600, angle=(-(90-bpa)),  fc='None', lw=2, ec='w')
+            if np.min(np.abs(freqs_mhz - freq_plt)) < 2.:
+                bd = np.argmin(np.abs(freqs_mhz - freq_plt)) 
+                bmaj,bmin,bpa = meta['bmaj'][bd],meta['bmin'][bd],meta['bpa'][bd]
+                beam0 = Ellipse((-fov/2*0.75, -fov/2*0.75), bmaj*3600,
+                        bmin*3600, angle=(-(90-bpa)),  fc='None', lw=2, ec='w')
 
-                        rmap_plt_ = smap.Map(np.squeeze(rdata[0, bd, :, :]/1e6), meta['header'])
-                        rmap_plt = pmX.Sunmap(rmap_plt_)
+                rmap_plt_ = smap.Map(np.squeeze(rdata[0, bd, :, :]/1e6), meta['header'])
+                rmap_plt = pmX.Sunmap(rmap_plt_)
 
-                        if apply_refraction_corr:
-                            # check if keyword is present
-                            if 'refra_shift_x' in meta.keys():
-                                com_x_corr = meta["refra_shift_x"][bd]
-                                com_y_corr = meta["refra_shift_y"][bd]
-                                rmap_plt.xrange = rmap_plt.xrange - com_x_corr*u.arcsec
-                                rmap_plt.yrange = rmap_plt.yrange - com_y_corr*u.arcsec
-                                 
-                        vmaxplt = np.percentile(rdata[0, bd, :, :]/1e6, 99.9)
-                        if np.isnan(vmaxplt):
-                             vmaxplt = np.inf
-                        im = rmap_plt.imshow(axes=ax, cmap='hinodexrt', vmin=0, vmax=vmaxplt)
-                        # set background black
+                if apply_refraction_param and not rfrcor:
+                    # check if keyword is present
+                    if 'refra_shift_x' in meta.keys():
+                        com_x_corr = meta["refra_shift_x"][bd]
+                        com_y_corr = meta["refra_shift_y"][bd]
+                        rmap_plt.xrange = rmap_plt.xrange - com_x_corr*u.arcsec
+                        rmap_plt.yrange = rmap_plt.yrange - com_y_corr*u.arcsec
+                         
+                vmaxplt = np.percentile(rdata[0, bd, :, :]/1e6, 99.9)
+                if np.isnan(vmaxplt):
+                     vmaxplt = np.inf
+                im = rmap_plt.imshow(axes=ax, cmap='hinodexrt', vmin=0, vmax=vmaxplt)
+                # set background black
 
-                        rmap_plt.draw_limb(ls='-', color='w', alpha=0.8)
-                        ax.add_artist(beam0)
+                rmap_plt.draw_limb(ls='-', color='w', alpha=0.5)
+                ax.add_artist(beam0)
 
-                        freq_mhz = meta['ref_cfreqs'][bd]/1e6
-                        ax.text(0.99, 0.02, r"$T_B^{\rm max}=$"+ str(np.round(vmaxplt,2))+'MK', color='w', ha='right', va='bottom',
-                                    fontsize=10, transform=ax.transAxes)
-                        
-                    else:
-                        ax.text(0.5, 0.5, 'No Data', color='w', 
-                                ha='center', va='center', fontsize=18, transform=ax.transAxes)
-                    ax.set_xlim([-fov/2, fov/2])
-                    ax.set_ylim([-fov/2, fov/2])
-                    
-                    
+                freq_mhz = meta['ref_cfreqs'][bd]/1e6
+                ax.text(0.99, 0.02, r"$T_B^{\rm max}=$"+ str(np.round(vmaxplt,2))+'MK', color='w', ha='right', va='bottom',
+                            fontsize=10, transform=ax.transAxes)
+                
+            else:
+                ax.text(0.5, 0.5, 'No Data', color='w', 
+                        ha='center', va='center', fontsize=18, transform=ax.transAxes)
+            ax.set_xlim([-fov/2, fov/2])
+            ax.set_ylim([-fov/2, fov/2])
 
-                    if i not in [8,9,10,11]: 
-                        ax.set_xlabel('')
-                        ax.get_xaxis().set_ticks([])
-                    if i not in [0, 4, 8]:
-                        ax.set_ylabel('')
-                        ax.get_yaxis().set_ticks([])
-                        
+            if i not in [8,9,10,11]: 
+                ax.set_xlabel('')
+                ax.get_xaxis().set_ticks([])
+            if i not in [0, 4, 8]:
+                ax.set_ylabel('')
+                ax.get_yaxis().set_ticks([])
+                
 
-                    # add logo
-                    if add_logo:
-                        img1 = base64.b64decode(njit_logo_str)
-                        img1 = io.BytesIO(img1)
-                        img1 = mpimg.imread(img1, format='png')
-                        img2 = base64.b64decode(caltech_logo)
-                        img2 = io.BytesIO(img2)
-                        img2 = mpimg.imread(img2, format='png')
+            # add logo
+            if add_logo:
+                img1 = base64.b64decode(njit_logo_str)
+                img1 = io.BytesIO(img1)
+                img1 = mpimg.imread(img1, format='png')
+                img2 = base64.b64decode(caltech_logo)
+                img2 = io.BytesIO(img2)
+                img2 = mpimg.imread(img2, format='png')
 
-                        ax_logo1 = fig.add_axes([0.015, 0.027, 0.07, 0.07])
-                        ax_logo1.imshow(img1)
-                        ax_logo1.axis('off')
-                        ax_logo2 = fig.add_axes([0.005,-0.003, 0.09, 0.08])
-                        ax_logo2.imshow(img2)
-                        ax_logo2.axis('off')
+                ax_logo1 = fig.add_axes([0.015, 0.035, 0.07, 0.07])
+                ax_logo1.imshow(img1)
+                ax_logo1.axis('off')
+                ax_logo2 = fig.add_axes([0.005,-0.003, 0.09, 0.08])
+                ax_logo2.imshow(img2)
+                ax_logo2.axis('off')
 
-                    # add figure title
-                    fig.suptitle('OVRO-LWA '+ str(meta['header']['date-obs'])[0:22], fontsize=12)
+            # add figure title
+            if rfrcor:
+                fig.suptitle('OVRO-LWA '+ str(meta['header']['date-obs'])[0:19] + ' [refraction corrected]', fontsize=12)
+            else:
+                fig.suptitle('OVRO-LWA '+ str(meta['header']['date-obs'])[0:19] + ' [original]', fontsize=12)
 
     return fig

--- a/ovrolwasolar/visualization.py
+++ b/ovrolwasolar/visualization.py
@@ -95,82 +95,81 @@ def slow_pipeline_default_plot(fname,
     fig = plt.figure(figsize=(8, 6.5))
     gs = gridspec.GridSpec(3, 4, left=0.07, right=0.98, top=0.94, bottom=0.10, wspace=0.02, hspace=0.02)
 
-    if True:
-        freqs_mhz = meta['ref_cfreqs']/1e6
-        for i in range(12):
-            ax = fig.add_subplot(gs[i])
-            freq_plt = freqs_plt[i]
-            ax.set_facecolor('black')
-            plt.setp(ax,xlabel='Solar X [arcsec]', ylabel='Solar Y [arcsec]')
-            ax.text(0.02, 0.98, '{0:.0f} MHz'.format(freq_plt), color='w', ha='left', va='top', 
-                    fontsize=11, transform=ax.transAxes)                
-            plt.setp(ax.yaxis.get_majorticklabels(),
-                      rotation=90, ha="center", va="center", rotation_mode="anchor")
+    freqs_mhz = meta['ref_cfreqs']/1e6
+    for i in range(12):
+        ax = fig.add_subplot(gs[i])
+        freq_plt = freqs_plt[i]
+        ax.set_facecolor('black')
+        plt.setp(ax,xlabel='Solar X [arcsec]', ylabel='Solar Y [arcsec]')
+        ax.text(0.02, 0.98, '{0:.0f} MHz'.format(freq_plt), color='w', ha='left', va='top', 
+                fontsize=11, transform=ax.transAxes)                
+        plt.setp(ax.yaxis.get_majorticklabels(),
+                  rotation=90, ha="center", va="center", rotation_mode="anchor")
 
-            if np.min(np.abs(freqs_mhz - freq_plt)) < 2.:
-                bd = np.argmin(np.abs(freqs_mhz - freq_plt)) 
-                bmaj,bmin,bpa = meta['bmaj'][bd],meta['bmin'][bd],meta['bpa'][bd]
-                beam0 = Ellipse((-fov/2*0.75, -fov/2*0.75), bmaj*3600,
-                        bmin*3600, angle=(-(90-bpa)),  fc='None', lw=2, ec='w')
+        if np.min(np.abs(freqs_mhz - freq_plt)) < 2.:
+            bd = np.argmin(np.abs(freqs_mhz - freq_plt)) 
+            bmaj,bmin,bpa = meta['bmaj'][bd],meta['bmin'][bd],meta['bpa'][bd]
+            beam0 = Ellipse((-fov/2*0.75, -fov/2*0.75), bmaj*3600,
+                    bmin*3600, angle=(-(90-bpa)),  fc='None', lw=2, ec='w')
 
-                rmap_plt_ = smap.Map(np.squeeze(rdata[0, bd, :, :]/1e6), meta['header'])
-                rmap_plt = pmX.Sunmap(rmap_plt_)
+            rmap_plt_ = smap.Map(np.squeeze(rdata[0, bd, :, :]/1e6), meta['header'])
+            rmap_plt = pmX.Sunmap(rmap_plt_)
 
-                if apply_refraction_param and not rfrcor:
-                    # check if keyword is present
-                    if 'refra_shift_x' in meta.keys():
-                        com_x_corr = meta["refra_shift_x"][bd]
-                        com_y_corr = meta["refra_shift_y"][bd]
-                        rmap_plt.xrange = rmap_plt.xrange - com_x_corr*u.arcsec
-                        rmap_plt.yrange = rmap_plt.yrange - com_y_corr*u.arcsec
-                         
-                vmaxplt = np.percentile(rdata[0, bd, :, :]/1e6, 99.9)
-                if np.isnan(vmaxplt):
-                     vmaxplt = np.inf
-                im = rmap_plt.imshow(axes=ax, cmap='hinodexrt', vmin=0, vmax=vmaxplt)
-                # set background black
+            if apply_refraction_param and not rfrcor:
+                # check if keyword is present
+                if 'refra_shift_x' in meta.keys():
+                    com_x_corr = meta["refra_shift_x"][bd]
+                    com_y_corr = meta["refra_shift_y"][bd]
+                    rmap_plt.xrange = rmap_plt.xrange - com_x_corr*u.arcsec
+                    rmap_plt.yrange = rmap_plt.yrange - com_y_corr*u.arcsec
+                     
+            vmaxplt = np.percentile(rdata[0, bd, :, :]/1e6, 99.9)
+            if np.isnan(vmaxplt):
+                 vmaxplt = np.inf
+            im = rmap_plt.imshow(axes=ax, cmap='hinodexrt', vmin=0, vmax=vmaxplt)
+            # set background black
 
-                rmap_plt.draw_limb(ls='-', color='w', alpha=0.5)
-                ax.add_artist(beam0)
+            rmap_plt.draw_limb(ls='-', color='w', alpha=0.5)
+            ax.add_artist(beam0)
 
-                freq_mhz = meta['ref_cfreqs'][bd]/1e6
-                ax.text(0.99, 0.02, r"$T_B^{\rm max}=$"+ str(np.round(vmaxplt,2))+'MK', color='w', ha='right', va='bottom',
-                            fontsize=10, transform=ax.transAxes)
-                
-            else:
-                ax.text(0.5, 0.5, 'No Data', color='w', 
-                        ha='center', va='center', fontsize=18, transform=ax.transAxes)
-            ax.set_xlim([-fov/2, fov/2])
-            ax.set_ylim([-fov/2, fov/2])
+            freq_mhz = meta['ref_cfreqs'][bd]/1e6
+            ax.text(0.99, 0.02, r"$T_B^{\rm max}=$"+ str(np.round(vmaxplt,2))+'MK', color='w', ha='right', va='bottom',
+                        fontsize=10, transform=ax.transAxes)
+            
+        else:
+            ax.text(0.5, 0.5, 'No Data', color='w', 
+                    ha='center', va='center', fontsize=18, transform=ax.transAxes)
+        ax.set_xlim([-fov/2, fov/2])
+        ax.set_ylim([-fov/2, fov/2])
 
-            if i not in [8,9,10,11]: 
-                ax.set_xlabel('')
-                ax.get_xaxis().set_ticks([])
-            if i not in [0, 4, 8]:
-                ax.set_ylabel('')
-                ax.get_yaxis().set_ticks([])
-                
+        if i not in [8,9,10,11]: 
+            ax.set_xlabel('')
+            ax.get_xaxis().set_ticks([])
+        if i not in [0, 4, 8]:
+            ax.set_ylabel('')
+            ax.get_yaxis().set_ticks([])
+            
 
-            # add logo
-            if add_logo:
-                img1 = base64.b64decode(njit_logo_str)
-                img1 = io.BytesIO(img1)
-                img1 = mpimg.imread(img1, format='png')
-                img2 = base64.b64decode(caltech_logo)
-                img2 = io.BytesIO(img2)
-                img2 = mpimg.imread(img2, format='png')
+        # add logo
+        if add_logo:
+            img1 = base64.b64decode(njit_logo_str)
+            img1 = io.BytesIO(img1)
+            img1 = mpimg.imread(img1, format='png')
+            img2 = base64.b64decode(caltech_logo)
+            img2 = io.BytesIO(img2)
+            img2 = mpimg.imread(img2, format='png')
 
-                ax_logo1 = fig.add_axes([0.015, 0.035, 0.07, 0.07])
-                ax_logo1.imshow(img1)
-                ax_logo1.axis('off')
-                ax_logo2 = fig.add_axes([0.005,-0.003, 0.09, 0.08])
-                ax_logo2.imshow(img2)
-                ax_logo2.axis('off')
+            ax_logo1 = fig.add_axes([0.015, 0.035, 0.07, 0.07])
+            ax_logo1.imshow(img1)
+            ax_logo1.axis('off')
+            ax_logo2 = fig.add_axes([0.005,-0.003, 0.09, 0.08])
+            ax_logo2.imshow(img2)
+            ax_logo2.axis('off')
 
-            # add figure title
-            if rfrcor:
-                fig.suptitle('OVRO-LWA '+ str(meta['header']['date-obs'])[0:19] + ' [refraction corrected]', fontsize=12)
-            else:
-                fig.suptitle('OVRO-LWA '+ str(meta['header']['date-obs'])[0:19] + ' [original]', fontsize=12)
+        # add figure title
+        if rfrcor:
+            fig.suptitle('OVRO-LWA '+ str(meta['header']['date-obs'])[0:19] + ' [refraction corrected]', fontsize=12)
+        else:
+            fig.suptitle('OVRO-LWA '+ str(meta['header']['date-obs'])[0:19] + ' [original]', fontsize=12)
 
     return fig


### PR DESCRIPTION
- refraction_correction.py: bug fix for CRPIX1 and CRPIX2 updates in save_resample_align(), which used to apply to the second and third axis. Updates for FITS headers and history
- move compression-related functions to utils.py
- add a minimum fraction of frequency channels to fit refraction coefficients. Used to be hard-coded to 5.
- add pixel-size-aware feature in remove_small_objects()
- visualization.py: check REFCOR in the fits header and add a note in the figure title. 