### PR TITLE
small updates for refraction record and visualization

### DIFF
--- a/ovrolwasolar/refraction_correction.py
+++ b/ovrolwasolar/refraction_correction.py
@@ -138,7 +138,7 @@ def refraction_fit_param(fname, thresh_freq=45e6, overbright=2.0e6, min_freqfrac
 
     #com_x_fitted = px[0] * 1 / freqs_arr ** 2 + px[1]
     #com_y_fitted = py[0] * 1 / freqs_arr ** 2 + py[1]
-    reftime = meta['header']['date-obs']
+    reftime = meta['header']['date-obs'][:19]
 
     if return_record:
         return {'Time':reftime, 'px0':px[0], 'px1':px[1], 'py0':py[0], 'py1':py[1]}

--- a/ovrolwasolar/visualization.py
+++ b/ovrolwasolar/visualization.py
@@ -96,6 +96,7 @@ def slow_pipeline_default_plot(fname,
     gs = gridspec.GridSpec(3, 4, left=0.07, right=0.98, top=0.94, bottom=0.10, wspace=0.02, hspace=0.02)
 
     freqs_mhz = meta['ref_cfreqs']/1e6
+    axes = []
     for i in range(12):
         ax = fig.add_subplot(gs[i])
         freq_plt = freqs_plt[i]
@@ -148,7 +149,7 @@ def slow_pipeline_default_plot(fname,
         if i not in [0, 4, 8]:
             ax.set_ylabel('')
             ax.get_yaxis().set_ticks([])
-            
+        axes.append(ax)
 
         # add logo
         if add_logo:
@@ -172,4 +173,4 @@ def slow_pipeline_default_plot(fname,
         else:
             fig.suptitle('OVRO-LWA '+ str(meta['header']['date-obs'])[0:19] + ' [original]', fontsize=12)
 
-    return fig
+    return fig, axes


### PR DESCRIPTION
- The precision of time stamp for refraction records only goes to second (previously unlimited)
- visualization.py also returns the axes for the main panels. Previously hard to find.