### PR TITLE
Implementing polarisation calibration for routine imaging

### DIFF
--- a/ovrolwasolar/leakage_correction.py
+++ b/ovrolwasolar/leakage_correction.py
@@ -313,7 +313,7 @@ def determine_multifreq_leakage(fname,overbright=1.0e6,background_factor=1/8,\
     num_stokes=shape[0]
     num_freqs=shape[1]
     
-    leak_frac=np.zeros((num_freqs,4))
+    leak_frac=np.ones((num_freqs,4))*(-1000) #### -1000 is being used as a dummy number
     
     stokes_order=meta_header['polorder'].split(',')
 
@@ -336,9 +336,7 @@ def determine_multifreq_leakage(fname,overbright=1.0e6,background_factor=1/8,\
         if success:
             for j,stokes in enumerate(stokes_order):
                 leak_frac[freq_ind,arranging_order[stokes]]=leak[j]
-        else:
-            leak_frac[freq_ind,:]=-1000 ### dummy number to show 
-                                                               ### that this could not be determined
+        
     return leak_frac
 
 def write_to_database(fname,leak_frac,database,low_freq=30,high_freq=90,freq_sep=1):

--- a/ovrolwasolar/leakage_correction.py
+++ b/ovrolwasolar/leakage_correction.py
@@ -1,0 +1,362 @@
+from . import refraction_correction as rfc
+from astropy.io import fits
+import pandas as pd
+from shutil import copyfile
+from astropy.time import Time
+from suncasa.io import ndfits
+import numpy as np
+from . import utils
+import os,logging,h5py
+
+class leakage_database():
+    def __init__(self,database):
+        self.stokes_num=4
+        self.leakage_database=database
+        self.leakage_freq_sep=5
+        self.low_freq=17.5
+        self.high_freq=90.5
+        
+    
+    def add_database_headers(self):
+        with h5py.File(self.leakage_database,'a') as hf:
+            hf.attrs['freq_sep']=self.leakage_freq_sep
+            hf.attrs['low_freq']=self.low_freq
+            hf.attrs['high_freq']=self.high_freq
+        
+    def write_leakage_frac_to_database(self,datetime_mjd,alt,az,freqs,leak_frac):
+        '''
+        :param leakage_alt/az_sep: The alt/az separation in which data will be written to database
+                                 in MHz. This can vary in each solve instance.
+        :type : float
+        :param datetime_mjd: mjd of the time you want to write
+        :type datetime_mjd: float
+        :param alt: Altitude in degree
+        :type alt: float
+        :param az: Azimuth in degree
+        :type az: float
+        :param freqs: Frequencies for which the data is being written
+        :type freqs: numpy ndarray
+        :param leak_frac: Array with shape num_freqs x 4. the 4 pols are 
+                            arranged in I_frac, Q_frac, U_frac, Vfrac. I_frac is ignored
+        :type leak_frac: list
+        
+        Only write to database if you have values for Q,U,V
+        '''
+        
+        entry_to_write={}
+        entry_to_write['datetime_mjd']=datetime_mjd
+        entry_to_write['alt']=alt
+        entry_to_write['az']=az
+        
+        for j,freq1 in enumerate(freqs):
+            entry_to_write['Q/I_'+str(int(freq1))+"MHz"]=leak_frac[j,1]
+            entry_to_write['U/I_'+str(int(freq1))+"MHz"]=leak_frac[j,2]
+            entry_to_write['V/I_'+str(int(freq1))+"MHz"]=leak_frac[j,3]
+            
+        self.add_leakage_entry(entry_to_write)
+        self.add_database_headers()
+        return
+    
+    def remove_rows_from_leakage_database(database,mjd_to_drop):
+        '''
+        Reads the database file, filters out and then recreates with same name
+        '''
+        data=pd.read_hdf(database,'I_leakage')
+        datetime_mjd=data['datetime_mjd']
+        pos=np.where(abs(datetime_mjd-mjd_to_drop)>=1)[0]
+        
+        keys=data.keys()
+        
+        new_data={}
+        for key in keys:
+            new_data[key]=np.array(data[key])[pos]
+        
+        df=pd.DataFrame(new_data)
+        df.to_hdf(database,key='I_leakage',index=False,format='table',complevel=3)
+        return
+    
+    def add_leakage_entry(self,entry):
+        '''
+        entry should be a pandas dataframe/dictionary with the following keys
+        datetime_mjd, az (degrees), el (degrees), Q/I leakage, U/I leakage, V/I leakage
+        
+        column names: datetime_mjd, az,el, Q/I_34MHz, U/I_34MHz, V/I_34MHz, \
+                        Q/I_34MHz_mean_sub, U/I_34MHz_mean_sub, V/I_34MHz_mean_sub
+        Similar to this we do the following frequencies 34, 39, 43, 48, 52,\
+        57, 62, 66, 71, 75, 80 and 84 MHz. 
+        
+        Leakage values more than 100, implies no solution found.
+        
+        Also if database exists, we assume that some entries also exist. 
+        
+        Only appends entries which have unique datetimes
+        '''
+        if not hasattr(self,"leakage_database"):
+            if not database:
+                raise RuntimeError("Please provide leakage database name")
+            self.leakage_database=database
+         
+        df=pd.DataFrame(entry,index=[0])
+        
+        if not os.path.isfile(self.leakage_database):
+            logging.debug("Leakage database does not exist. Creating one")
+            ## using table format for appending, searching, selecting subsets
+            df.to_hdf(self.leakage_database,key='I_leakage',index=False,format='table',complevel=3)
+            return
+        ## This will only be done if the file already exists
+        existing_df=pd.read_hdf(self.leakage_database,key='I_leakage',columns=['datetime_mjd'])
+        
+        ## remove duplicate datetime entries
+        old_datetimes=existing_df['datetime_mjd']
+        new_datetimes=df['datetime_mjd']
+        times,old_frame_ind, new_frame_ids=np.intersect1d(old_datetimes,new_datetimes, return_indices=True)
+        
+        if new_frame_ids.size==new_datetimes.size:
+            logging.debug("No unique entries found. Exiting")
+            print ("No unique entries found. Exiting")
+            return
+            
+        df.drop(index=new_frame_ids)
+        
+        ## append the new entries to the database
+        ## using table format for appending, searching, selecting subsets
+        df.to_hdf(self.leakage_database,key='I_leakage',mode='r+',append=True,\
+                        index=False,complevel=3,format='table')
+        return
+    
+    def get_leakage_from_database(self):
+        '''
+        This reads the database and produces the leakage fractions for all
+        stokes by doing a nearest neighbour interpolation in alt-az and linear
+        interpolation in frequency.
+        '''
+        self.determine_beam_leakage_fractions_from_db(max_pol_ind=3)
+    
+    def determine_leakage_fractions_from_db(self,alt,az,freqs):
+        '''
+        This function reads in the leakage database and then uses it to calculate the
+        leakage fraction at all the data times
+        :param freqs: Frequencies for which leakage is needed in MHz
+        :param alt: altitude of source in degree
+        :param az: azimuth of source in degree
+        '''
+        
+        with h5py.File(self.leakage_database,'r') as hf:
+            freqs_in_db=np.arange(hf.attrs['low_freq'],hf.attrs['high_freq'],hf.attrs['freq_sep'],dtype=int)
+        
+        data=pd.read_hdf(self.leakage_database,key='I_leakage',columns=['az','alt'])
+        database_az=np.array(data['az'])
+        database_alt=np.array(data['alt'])
+        
+        num_freqs=freqs.size
+        leakage_fractions=np.zeros((4,num_freqs))
+        
+        for i in range(num_freqs):
+            data_freq=freqs[i]
+            freq1,freq2=self.choose_freqs_to_load(freqs_in_db,data_freq)
+            print (data_freq,freqs_in_db,freq1,freq2)
+            
+            if not freq1 or not freq2:
+                leakage_fractions[1:,i]=np.nan
+                continue
+            for j,pol in zip(range(1,4),['Q/I','U/I','V/I']):
+                
+                leakage_fractions[j,i]=self.calculate_leakages_from_database(data_freq,freq1,freq2,\
+                                            pol,az,alt,database_az,database_alt)  
+        return leakage_fractions
+    
+    @staticmethod    
+    def choose_freqs_to_load(freqs_in_db,data_freq):
+        '''
+        This function provides the 2 nearest frequencies (greater and smaller) to the
+        current frequency for which the leakages are needed. This is done to reduce
+        the amount of data loaded. We will only load these particular columns
+        :param freqs_in_db: Frequencies (in MHz) present in the database. This is not read, but generated
+                            based on the header present in the hdf5 file.
+        :type freqs_in_db : np.array
+        :param data_freq: The current frequency in MHz for which leakages are required
+        :type data_freq: float
+        '''
+        if data_freq<freqs_in_db[0]:
+            return freqs_in_db[0],None
+        if data_freq>freqs_in_db[-1]:
+            return  freqs_in_db[-1], None  
+        
+        indices=np.argsort(np.abs(freqs_in_db-data_freq))
+        
+        return freqs_in_db[indices[0]],freqs_in_db[indices[1]]    
+
+    def calculate_leakages_from_database(self,data_freq,freq1,freq2,pol,az,alt,database_az,database_alt):
+        columns=[pol+"_"+str(int(freq1))+"MHz",pol+"_"+str(int(freq2))+"MHz"]
+
+        data=pd.read_hdf(self.leakage_database,key='I_leakage',columns=columns)
+        
+        leak1_database_azalt=np.array(data[columns[0]])
+        leak1_data_azalt=griddata((database_az,database_alt),leak1_database_azalt,(az,alt),method='nearest')
+        
+        leak2_database_azalt=np.array(data[columns[1]])
+        leak2_data_azalt=griddata((database_az,database_alt),leak2_database_azalt,(az,alt),method='nearest')
+        
+        leak_data_azalt=(leak2_data_azalt-leak1_data_azalt)/(freq2-freq1)*(data_freq-freq1)+\
+                                         leak1_data_azalt ## fitting line
+        
+        if abs(freq2-freq1)<=self.freq_sep: ### I am putting a small tolerance here.
+            return leak_data_azalt
+        if abs(freq2-freq)>self.freq_sep:
+            return leak2_data_azalt
+        if abs(freq1-freq)>self.freq_sep:
+            return leak1_data_azalt
+        return np.nan
+
+def find_robust_median(data,thresh=5):
+    median=np.nanmedian(data)
+    for i in range(5):
+        mad=np.nanmedian(np.abs(data-median))
+        pos=np.where(np.abs(data-median)>thresh*mad)[0]
+        data[pos]=np.nan
+        median=np.nanmedian(data)
+    return median
+
+def determine_leakage_single_freq(stokes_data,frequency, background_factor, \
+                                    min_size, overbright, stokes_order, min_pix=100):
+    
+    Iind=stokes_order.index('I')
+    Idata=stokes_data[Iind,:,:]
+    pos=find_quiet_sun_pixels(Idata,frequency, background_factor, min_size, overbright)
+  
+    if pos[0].size<min_pix:
+        return False,np.zeros(4)
+    
+    leak_frac=np.zeros(len(stokes_order))
+    for j,stokes in enumerate(stokes_order):
+        if stokes!='I':
+            leak=find_robust_median(stokes_data[j][pos]/Idata[pos])
+            leak_frac[j]=leak
+    return True,leak_frac
+    
+        
+def find_quiet_sun_pixels(Idata,frequency, background_factor, min_size, overbright):
+    thresh=rfc.thresh_func(frequency)*background_factor
+    pos=np.where((Idata>thresh) & (Idata<overbright))
+    return pos
+    
+                     
+def determine_multifreq_leakage(fname,overbright=1.0e6,background_factor=1/8,\
+                                min_size_50=1000,\
+                                bands=['32MHz', '36MHz', '41MHz', \
+                    '46MHz', '50MHz', '55MHz', '59MHz', '64MHz', '69MHz', '73MHz', \
+                    '78MHz', '82MHz']):
+    '''
+    image_cube is multi-frequency, multi-stokes image 4D
+    images for one time and frequency. While presence of I
+    image is essential, either all of Q,U,V images, or any 1
+    or 2 of them can be present.
+    Shape: Stokes X Freq x spatial axis x spatial axis
+    '''
+    
+    
+    meta, data = ndfits.read(fname)
+    
+    meta_header=meta['header']
+    
+    shape=data.shape
+    num_stokes=shape[0]
+    num_freqs=shape[1]
+    
+    leak_frac=np.zeros((num_freqs,4))
+    
+    stokes_order=meta_header['polorder'].split(',')
+    
+    arranging_order={'I':0,'Q':1,'U':2,'V':3}
+    
+    for freq_ind in range(num_freqs):
+        frequency=meta['ref_cfreqs'][freq_ind]
+        min_size = min_size_50/(meta_header['CDELT1']/60.)**2./(frequency/50e6)**2.
+        success,leak=determine_leakage_single_freq(data[:,freq_ind,:],frequency,\
+                                            background_factor, min_size, overbright, stokes_order)
+        if success:
+            for j,stokes in enumerate(stokes_order):
+                leak_frac[freq_ind,arranging_order[stokes]]=leak[j]
+        else:
+            leak_frac[freq_ind,:]=-1000 ### dummy number to show 
+                                                               ### that this could not be determined
+    return leak_frac
+
+def write_to_database(fname,leak_frac,outfile):
+    meta, data = ndfits.read(fname)    
+    meta_header=meta['header']
+    freqs=meta['ref_cfreqs']*1e-6
+    
+    datetime=Time(meta_header['DATE-OBS'])
+    az,alt=utils.get_solar_altaz_multiple_times(datetime)
+    
+    db=leakage_database(outfile)
+    pos=np.where(leak_frac>-10)[0] ## searching for dummy number. Dummy number is -1000
+    if pos.size!=0:
+        db.write_leakage_frac_to_database(datetime.mjd,alt,az,freqs[pos],leak_frac[pos])
+    return
+    
+def do_leakage_correction(image_cube,primary_beam_database,outfile=None):
+    if outfile is None:
+        outfile = './' + os.path.basename(image_cube).replace('lev1.5','lev2.5')
+        outfile = './' + os.path.basename(image_cube).replace('lev1','lev2')
+        
+    copyfile(image_cube, outfile)
+    meta, data = ndfits.read(image_cube)
+    
+    shape=data.shape
+    num_stokes=shape[0]
+    num_freqs=shape[1]
+    freq_MHz=meta['ref_cfreqs']*1e-6
+    meta_header=meta['header']
+    stokes_order=meta_header['polorder'].split(',')
+    
+    datetime=Time(meta_header['DATE-OBS'])
+    az,alt=utils.get_solar_altaz_multiple_times(datetime)
+    
+    db=leakage_database(primary_beam_database)
+    leak_frac=db.determine_leakage_fractions_from_db(alt,az,freq_MHz)
+    print (leak_frac)
+    arrange_order={'I':0,'Q':1,'U':2,'V':3}
+    
+    I_ind=stokes_order.index('I')
+    leakage_to_write=np.zeros((num_freqs,len(stokes_order)))
+    
+    for freq_ind,frequency in enumerate(freq_MHz):
+        for stokes_ind,stokes in enumerate(stokes_order):
+            if stokes!='I':
+                data[stokes_ind,freq_ind,:,:]-=leak_frac[arrange_order[stokes],freq_ind]*\
+                                                data[I_ind,freq_ind,:,:]
+                if np.isnan(leak_frac[arrange_order[stokes],freq_ind]):
+                    leak_frac[arrange_order[stokes],freq_ind]=-1000
+                leakage_to_write[freq_ind,stokes_ind]=leak_frac[arrange_order[stokes],freq_ind]
+    
+    cols=[]
+    for stokes_ind,stokes in enumerate(stokes_order):
+        fitscol=fits.Column(name=stokes+"_leak",format='E',array=leakage_to_write[:,stokes_ind])  
+                    ## E stands for single precision float (32-bit). Change to D for double precision
+                    ## see https://docs.astropy.org/en/stable/io/fits/usage/table.html#column-creation
+        cols.append(fitscol)
+    header={}
+    header['leakage_corrected']=True
+    header['dummy_leakage']=-1000
+    ndfits.update(outfile,new_data=data,new_columns=cols, new_header_entries=header)
+    return outfile
+    
+
+
+    
+                
+                                                
+    
+    
+            
+        
+        
+    
+    
+    
+
+            
+    
+    

--- a/ovrolwasolar/primary_beam.py
+++ b/ovrolwasolar/primary_beam.py
@@ -379,7 +379,7 @@ class jones_beam:
             ### of I used. I= 0.5*(XX+YY).
                 self.max_e[i]=np.sqrt(0.5*(xpol_phi_max[i]**2+xpol_theta_max[i]**2+\
                                         ypol_phi_max[i]**2+ypol_theta_max[i]**2))
-        except:
+        except Exception as e:
             logging.warning("Beam file does not exist in give path."+\
                     "Switching to analytical beam.")
             self._beamfile=None
@@ -514,7 +514,7 @@ class jones_beam:
                                          (M10,M11, M12, M13),\
                                          (M20, M21, M22, M23),\
                                          (M30, M31, M32, M33)) (I,Q,U,V).T
-        Note that this Muller Matrix is normalised with respect to I.
+        Note that this Muller Matrix is not normalised.
         '''
         XY_muller_matrix=self.get_muller_matrix_XY(jones_matrix)
         T=0.5*np.array([[1,0,0,1],[1,0,0,-1],[0,1,1,0],\

--- a/ovrolwasolar/primary_beam.py
+++ b/ovrolwasolar/primary_beam.py
@@ -514,7 +514,7 @@ class jones_beam:
                                          (M10,M11, M12, M13),\
                                          (M20, M21, M22, M23),\
                                          (M30, M31, M32, M33)) (I,Q,U,V).T
-        Note that this Muller Matrix is not normalised.
+        Note that this Muller Matrix is normalised with respect to I.
         '''
         XY_muller_matrix=self.get_muller_matrix_XY(jones_matrix)
         T=0.5*np.array([[1,0,0,1],[1,0,0,-1],[0,1,1,0],\

--- a/ovrolwasolar/solar_pipeline.py
+++ b/ovrolwasolar/solar_pipeline.py
@@ -223,7 +223,7 @@ def image_ms(solar_ms, calib_ms=None, bcal=None, do_selfcal=True, imagename='sun
                                    size=imsize , scale=cell, pol=pol, fast_vis=fast_vis, 
                                    field=','.join([str(i) for i in range(num_fields)]))
         if apply_primary_beam:
-            utils.correct_primary_beam(imagename, pol=pol, fast_vis=fast_vis)
+            utils.correct_primary_beam_self_terms(imagename, pol=pol, fast_vis=fast_vis)
         if not fast_vis:
             image_list=[]
             for n,pola in enumerate(['I','Q','U','V','XX','YY']):
@@ -377,7 +377,7 @@ def image_ms_quick(solar_ms, calib_ms=None, bcal=None, do_selfcal=True, imagenam
         deconvolve.run_wsclean(outms, imagename=imagename, auto_mask=5, minuv_l='0', predict=False, 
                                size=imsize, scale=cell, pol=pol)
         logging.debug('Correcting for the primary beam at the location of Sun')
-        utils.correct_primary_beam(imagename, pol=pol)
+        utils.correct_primary_beam_self_terms(imagename, pol=pol)
         for n,pola in enumerate(['I','Q','U','V','XX','YY']):
             if os.path.isfile(imagename+ "-"+pola+"-image.fits"):
                 helio_image = utils.convert_to_heliocentric_coords(outms, imagename+ "-"+pola+"-image.fits")

--- a/ovrolwasolar/solar_pipeline.py
+++ b/ovrolwasolar/solar_pipeline.py
@@ -223,7 +223,7 @@ def image_ms(solar_ms, calib_ms=None, bcal=None, do_selfcal=True, imagename='sun
                                    size=imsize , scale=cell, pol=pol, fast_vis=fast_vis, 
                                    field=','.join([str(i) for i in range(num_fields)]))
         if apply_primary_beam:
-            utils.correct_primary_beam(outms, imagename, pol=pol, fast_vis=fast_vis)
+            utils.correct_primary_beam(imagename, pol=pol, fast_vis=fast_vis)
         if not fast_vis:
             image_list=[]
             for n,pola in enumerate(['I','Q','U','V','XX','YY']):
@@ -268,7 +268,7 @@ def image_ms_quick(solar_ms, calib_ms=None, bcal=None, do_selfcal=True, imagenam
              delete_allsky=True, sky_image=None, quiet=True, remove_strong_sources_only=False,
              src_sb_sol_area=200., src_sb_src_area=200., shape_sun_mask='circ', include_edge_source=-1,
              rm_flagged=True, rm_10lambda=True, selfcal_flagbackup=True,
-             use_selfcal_img_to_subtract=True):
+             use_selfcal_img_to_subtract=False):
     """
     Pipeline to calibrate and imaging a solar visibility. 
     This is the version that optimizes the speed with a somewhat reduced image dynamic range.
@@ -306,13 +306,13 @@ def image_ms_quick(solar_ms, calib_ms=None, bcal=None, do_selfcal=True, imagenam
 
     
     if rm_flagged:
-        solar_ms_new = solar_ms[:-3] + "_rm_bad_ants.ms"
+        solar_ms_new = solar_ms.replace('.ms',"_rm_bad_ants.ms")
         split(vis=solar_ms, outputvis=solar_ms_new, datacolumn='data', keepflags=False)
         solar_ms = solar_ms_new
 
     if rm_10lambda:
         flagdata(vis=solar_ms, mode='manual', uvrange='<10lambda', flagbackup=False)
-        solar_ms_new = solar_ms[:-3] + "_rm10lambda.ms"
+        solar_ms_new = solar_ms.replace(".ms","_rm10lambda.ms")
         split(vis=solar_ms, outputvis=solar_ms_new, datacolumn='data', keepflags=False)
         solar_ms = solar_ms_new
 
@@ -326,10 +326,10 @@ def image_ms_quick(solar_ms, calib_ms=None, bcal=None, do_selfcal=True, imagenam
         #                      partial_di_selfcal_rounds=[0, 0], pol=pol, refant=refant, caltable_folder=caltable_folder)
         mstime_str = utils.get_timestr_from_name(solar_ms)
         success = utils.put_keyword(solar_ms, 'di_selfcal_time', mstime_str, return_status=True)
-        success, imagename = selfcal.do_selfcal(solar_ms, num_phase_cal=num_phase_cal, num_apcal=num_apcal, logging_level=logging_level, pol=pol,
+        success, imagename = selfcal.do_selfcal(solar_ms, num_phase_cal=num_phase_cal, num_apcal=num_apcal, logging_level=logging_level, pol='I',
             refant=refant, niter0=niter0, niter_incr=niter_incr, caltable_folder=caltable_folder, auto_pix_fov=auto_pix_fov, quiet=quiet,
             flagbackup=selfcal_flagbackup)
-        outms_di = solar_ms[:-3] + "_selfcalibrated.ms"
+        outms_di = solar_ms.replace(".ms","_selfcalibrated.ms")
         if do_fluxscaling:
             logging.debug('Doing a flux scaling using background strong sources')
             fc=flux_scaling.flux_scaling(vis=solar_ms, min_beam_val=0.1, pol=pol)
@@ -377,7 +377,7 @@ def image_ms_quick(solar_ms, calib_ms=None, bcal=None, do_selfcal=True, imagenam
         deconvolve.run_wsclean(outms, imagename=imagename, auto_mask=5, minuv_l='0', predict=False, 
                                size=imsize, scale=cell, pol=pol)
         logging.debug('Correcting for the primary beam at the location of Sun')
-        utils.correct_primary_beam(outms, imagename, pol=pol)
+        utils.correct_primary_beam(imagename, pol=pol)
         for n,pola in enumerate(['I','Q','U','V','XX','YY']):
             if os.path.isfile(imagename+ "-"+pola+"-image.fits"):
                 helio_image = utils.convert_to_heliocentric_coords(outms, imagename+ "-"+pola+"-image.fits")
@@ -489,5 +489,5 @@ def apply_solutions_and_image(msname, bcal, imagename):
     change_phasecenter(outms)
     deconvolve.run_wsclean(outms, imagename=imagename, auto_mask=5, minuv_l='0', predict=False, 
                            size=1024, scale='1arcmin')
-    utils.correct_primary_beam(outms, imagename + "-image.fits")
+    utils.correct_primary_beam(imagename + "-image.fits")
     logging.info('Imaging completed for ' + msname)

--- a/ovrolwasolar/utils.py
+++ b/ovrolwasolar/utils.py
@@ -524,7 +524,7 @@ def correct_primary_beam_self_terms(imagename, pol='I',fast_vis=False):
     
     pb.read_beam_file()
     pb.srcjones(az=np.array([az]),el=np.array([alt]))
-    jones_matrices=pb.get_source_pol_factors(pb.jones_matrices[0,:,:])
+    #jones_matrices=pb.get_source_pol_factors(pb.jones_matrices[0,:,:])
     muller_matrix=pb.get_muller_matrix_stokes(pb.jones_matrices[0,:,:])
     
     if fast_vis==False:

--- a/ovrolwasolar/utils.py
+++ b/ovrolwasolar/utils.py
@@ -461,7 +461,7 @@ def correct_primary_beam_leakage_from_I(imagename,pol='I,Q,U,V',\
     pb=beam(freq=freq,beam_file_path=beam_file_path)
     pb.read_beam_file()
     pb.srcjones(az=np.array([az]),el=np.array([alt]))
-    jones_matrices=pb.get_source_pol_factors(pb.jones_matrices[0,:,:])
+#    jones_matrices=pb.get_source_pol_factors(pb.jones_matrices[0,:,:])
     muller_matrix=pb.get_muller_matrix_stokes(pb.jones_matrices[0,:,:])
     
     Iscale=muller_matrix[0,0].real

--- a/ovrolwasolar/visualization.py
+++ b/ovrolwasolar/visualization.py
@@ -15,7 +15,7 @@ from matplotlib.patches import Ellipse
 import base64
 import io
 import matplotlib.image as mpimg
-
+from . import utils
 
 # the functions to plot the data
 
@@ -78,7 +78,7 @@ def slow_pipeline_default_plot(fname,
             freqs_plt = [34.1, 38.7, 43.2, 47.8, 52.4, 57.0, 61.6, 66.2, 70.8, 75.4, 80.0, 84.5],
             fov = 7998, add_logo=True, apply_refraction_param=False, 
             spec_fits=None, spec_dur=600., spec_cmap='viridis', spec_vmin=None, spec_vmax=None, spec_norm='log',
-            spec_frange=[30., 88.]):
+            spec_frange=[30., 88.], apply_fiducial_primary_beam=False):
     """
     Function to plot the default pipeline output
 
@@ -94,6 +94,11 @@ def slow_pipeline_default_plot(fname,
     from suncasa.io import ndfits
     from suncasa.dspec import dspec
     meta, rdata = ndfits.read(fname)
+    
+    if not apply_fiducial_primary_beam:
+        obstime=Time(meta['header']['DATE-OBS'])
+        az,alt=utils.get_solar_altaz_multiple_times(obstime)
+        rdata[0,...]/=np.sin(alt*np.pi/180)**1.6 ### applying a sin beam
     t_img = Time(meta['header']['date-obs'])
     if 'rfrcor' in meta['header']:
         rfrcor = meta['header']


### PR DESCRIPTION
1. Supports leakage_correction, in Q,U,V
2. Ensures Q is conserved during self-calibration by assuming that antenna gains do not differ in X and Y. Ensures faster self-calibration using I only images
3. Crosshand calibration is supposed to be already added to the bandpass caltables. The code for generating the caltables will be updated through a different branch after verifications. 
4. Removed some unnecessary returns in refraction_correction module.

The code has been tested with multiple runs of the appropriately modified realtime pipeline. 